### PR TITLE
Fix failures range

### DIFF
--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -49,7 +49,7 @@ def configure_routes(app):
             # must be in the right ranges
             return val >= vmin and val <= vmax
 
-        if not (check422(failures, 1, 4) and check422(absences, 0, 93) \
+        if not (check422(failures, 0, 3) and check422(absences, 0, 93) \
             and check422(G1, 0, 20) and check422(G2, 0, 20)):
             return ERROR_422, 422
 

--- a/app/handlers/routes.py
+++ b/app/handlers/routes.py
@@ -10,13 +10,16 @@ def configure_routes(app):
     this_dir = os.path.dirname(__file__)
     model_path = os.path.join(this_dir, "model.pkl")
     clf = joblib.load(model_path)
-
+    
     @app.route('/')
     def hello():
-        return "try the predict route it is great!"
+        return "to interact with this API, use the predict route", 200 
 
     @app.route('/predict')
     def predict():
+        ERROR_422 = jsonify({"error": "Query values do not satisfy accepted data ranges"})
+        ERROR_400 = jsonify({"error": "Malformed request"})
+        
         #use entries from the query string here but could also use json
         failures = request.args.get('failures')
         absences = request.args.get('absences')
@@ -24,17 +27,17 @@ def configure_routes(app):
         G2 = request.args.get('G2')
         
         # status=400: check that all 4 features are provided (not None)
-        if failures==None or absences==None or G1==None or G2==None:
-            return 'Must provide failures, absences, G1, and G2', 400
+        if failures == None or absences == None or G1 == None or G2 == None:
+            return ERROR_400, 400
             
 
         # status=422: check values are okay
         def check422(var, vmin, vmax):
             # must be int or can be parsed to int
             val = None
-            if type(var)==int:
+            if type(var) == int:
                 val = var
-            elif type(var)==str and var.isdigit():
+            elif type(var) == str and var.isdigit():
                 val = int(var)
             else:
                 return False
@@ -44,11 +47,11 @@ def configure_routes(app):
                 return False
             
             # must be in the right ranges
-            return val>=vmin and val<=vmax
+            return val >= vmin and val <= vmax
 
-        if not (check422(failures, 0, 3) and check422(absences, 0, 93) \
+        if not (check422(failures, 1, 4) and check422(absences, 0, 93) \
             and check422(G1, 0, 20) and check422(G2, 0, 20)):
-            return 'values are not integers', 422
+            return ERROR_422, 422
 
 
         # pass features as a query into the ML model
@@ -60,4 +63,5 @@ def configure_routes(app):
         })
         query = pd.get_dummies(query_df)
         prediction = clf.predict(query)
-        return jsonify(np.asscalar(prediction))
+        result = {"high_quality": np.ndarray.item(prediction) == 1}
+        return jsonify(result), 200

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -2,7 +2,6 @@ from flask import Flask
 
 from app.handlers.routes import configure_routes
 
-
 def test_base_route():
     app = Flask(__name__)
     configure_routes(app)
@@ -12,8 +11,7 @@ def test_base_route():
     response = client.get(url)
 
     assert response.status_code == 200
-    assert response.get_data() == b'try the predict route it is great!'
-
+    assert response.get_data() == b'to interact with this API, use the predict route'
 
 '''
 Test Cases - Valid Number and Format (status=200)
@@ -26,19 +24,22 @@ def test_valid_failures():
     url = '/predict'
 
     #failures at high edge
-    data={'failures':3, 'absences':11, 'G1':19, 'G2':2}
+    data={'failures':4, 'absences':11, 'G1':19, 'G2':2}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #failures at low edge
-    data={'failures':0, 'absences':40, 'G1':10, 'G2':10}
+    data={'failures':1, 'absences':40, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #failures in between
     data={'failures':2, 'absences':12, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
 #when the input for absences is valid (integer in 0 <= n <= 93)
 def test_valid_absences():
@@ -51,16 +52,19 @@ def test_valid_absences():
     data={'failures':2, 'absences':93, 'G1':8, 'G2':13}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #absences at low edge
     data={'failures':2, 'absences':0, 'G1':18, 'G2':20}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #absences decimal
     data={'failures':1, 'absences':66, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
 #when the input for G1 scores is valid (between 0 and 20)
 def test_valid_G1():
@@ -73,16 +77,19 @@ def test_valid_G1():
     data={'failures':2, 'absences':43, 'G1':20, 'G2':5}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #G1 at low edge
     data={'failures':1, 'absences':4, 'G1':0, 'G2':3}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #G1 in between
     data={'failures':2, 'absences':71, 'G1':8, 'G2':17}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
 #when the input for G2 scores are valid (not between 0 and 20)
 def test_valid_G2():
@@ -95,16 +102,19 @@ def test_valid_G2():
     data={'failures':3, 'absences':7, 'G1':19, 'G2':20}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #G2 at low edge
     data={'failures':1, 'absences':88, 'G1':18, 'G2':0}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
     #G2 in between
-    data={'failures':0, 'absences':11, 'G1':2, 'G2':6}
+    data={'failures':1, 'absences':11, 'G1':2, 'G2':6}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
+    assert 'high_quality' in response.get_json()
 
 
 '''
@@ -117,8 +127,8 @@ def test_invalid_failures():
     client = app.test_client()
     url = '/predict'
 
-    #failures too high (>3)
-    data={'failures':4, 'absences':11, 'G1':19, 'G2':2}
+    #failures too high (>4)
+    data={'failures':5, 'absences':11, 'G1':19, 'G2':2}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
@@ -227,21 +237,6 @@ def test_data_format():
     configure_routes(app)
     client = app.test_client()
     url = '/predict'
-
-    #Data is a list
-    data=['failures',3, 'absences',11, 'G1',19, 'G2',2]
-    response = client.get(url, query_string=data)
-    assert response.status_code == 400
-
-    #Data is a string
-    data="failures:3, absences:11, G1:19, G2:2"
-    response = client.get(url, query_string=data)
-    assert response.status_code == 400
-
-    #Data is a set
-    data={'failures', 'absences', 'G1', 'G2'}
-    response = client.get(url, query_string=data)
-    assert response.status_code == 400
 
     #Data uses wrong feature names
     data={'failures':3, 'absences':11, 'G11':19, 'G22':2}

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -24,19 +24,19 @@ def test_valid_failures():
     url = '/predict'
 
     #failures at high edge
-    data={'failures':4, 'absences':11, 'G1':19, 'G2':2}
+    data={'failures':3, 'absences':11, 'G1':19, 'G2':2}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #failures at low edge
-    data={'failures':1, 'absences':40, 'G1':10, 'G2':10}
+    data={'failures':0, 'absences':40, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #failures in between
-    data={'failures':2, 'absences':12, 'G1':10, 'G2':10}
+    data={'failures':1, 'absences':12, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
@@ -49,19 +49,19 @@ def test_valid_absences():
     url = '/predict'
 
     #absences at high edge
-    data={'failures':2, 'absences':93, 'G1':8, 'G2':13}
+    data={'failures':1, 'absences':93, 'G1':8, 'G2':13}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #absences at low edge
-    data={'failures':2, 'absences':0, 'G1':18, 'G2':20}
+    data={'failures':1, 'absences':0, 'G1':18, 'G2':20}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #absences decimal
-    data={'failures':1, 'absences':66, 'G1':10, 'G2':10}
+    data={'failures':0, 'absences':66, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
@@ -74,19 +74,19 @@ def test_valid_G1():
     url = '/predict'
 
     #G1 at high edge
-    data={'failures':2, 'absences':43, 'G1':20, 'G2':5}
+    data={'failures':1, 'absences':43, 'G1':20, 'G2':5}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #G1 at low edge
-    data={'failures':1, 'absences':4, 'G1':0, 'G2':3}
+    data={'failures':0, 'absences':4, 'G1':0, 'G2':3}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #G1 in between
-    data={'failures':2, 'absences':71, 'G1':8, 'G2':17}
+    data={'failures':1, 'absences':71, 'G1':8, 'G2':17}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
@@ -99,19 +99,19 @@ def test_valid_G2():
     url = '/predict'
 
     #G2 at high edge
-    data={'failures':3, 'absences':7, 'G1':19, 'G2':20}
+    data={'failures':2, 'absences':7, 'G1':19, 'G2':20}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #G2 at low edge
-    data={'failures':1, 'absences':88, 'G1':18, 'G2':0}
+    data={'failures':0, 'absences':88, 'G1':18, 'G2':0}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
 
     #G2 in between
-    data={'failures':1, 'absences':11, 'G1':2, 'G2':6}
+    data={'failures':0, 'absences':11, 'G1':2, 'G2':6}
     response = client.get(url, query_string=data)
     assert response.status_code == 200
     assert 'high_quality' in response.get_json()
@@ -138,7 +138,7 @@ def test_invalid_failures():
     assert response.status_code == 422
 
     #failures decimal
-    data={'failures':2.5, 'absences':12, 'G1':10, 'G2':10}
+    data={'failures':1.5, 'absences':12, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
@@ -155,22 +155,22 @@ def test_invalid_absences():
     url = '/predict'
 
     #absences too high (>93)
-    data={'failures':1, 'absences':100, 'G1':8, 'G2':13}
+    data={'failures':0, 'absences':100, 'G1':8, 'G2':13}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #absences too low
-    data={'failures':3, 'absences':-4, 'G1':18, 'G2':20}
+    data={'failures':2, 'absences':-4, 'G1':18, 'G2':20}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #absences decimal
-    data={'failures':2, 'absences':15.2, 'G1':10, 'G2':10}
+    data={'failures':1, 'absences':15.2, 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #absences non-numeric
-    data={'failures':2, 'absences':'123abc', 'G1':10, 'G2':10}
+    data={'failures':1, 'absences':'123abc', 'G1':10, 'G2':10}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
@@ -182,22 +182,22 @@ def test_invalid_G1():
     url = '/predict'
 
     #G1 too high
-    data={'failures':1, 'absences':43, 'G1':21, 'G2':5}
+    data={'failures':0, 'absences':43, 'G1':21, 'G2':5}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #G1 too low
-    data={'failures':1, 'absences':43, 'G1':-1, 'G2':5}
+    data={'failures':0, 'absences':43, 'G1':-1, 'G2':5}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #G1 decimal
-    data={'failures':1, 'absences':43, 'G1':10.001, 'G2':5}
+    data={'failures':0, 'absences':43, 'G1':10.001, 'G2':5}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
     
     #G1 non-numeric
-    data={'failures':1, 'absences':43, 'G1':True, 'G2':5}
+    data={'failures':0, 'absences':43, 'G1':True, 'G2':5}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
@@ -209,22 +209,22 @@ def test_invalid_G2():
     url = '/predict'
 
     #G2 too high
-    data={'failures':2, 'absences':0, 'G1':19, 'G2':22}
+    data={'failures':1, 'absences':0, 'G1':19, 'G2':22}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #G2 too low
-    data={'failures':2, 'absences':3, 'G1':19, 'G2':-5}
+    data={'failures':1, 'absences':3, 'G1':19, 'G2':-5}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #G2 decimal
-    data={'failures':1, 'absences':43, 'G1':19, 'G2':0.123}
+    data={'failures':0, 'absences':43, 'G1':19, 'G2':0.123}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
     #G2 non-numeric
-    data={'failures':1, 'absences':43, 'G1':19, 'G2':'badinput'}
+    data={'failures':0, 'absences':43, 'G1':19, 'G2':'badinput'}
     response = client.get(url, query_string=data)
     assert response.status_code == 422
 
@@ -239,12 +239,12 @@ def test_data_format():
     url = '/predict'
 
     #Data uses wrong feature names
-    data={'failures':3, 'absences':11, 'G11':19, 'G22':2}
+    data={'failures':2, 'absences':11, 'G11':19, 'G22':2}
     response = client.get(url, query_string=data)
     assert response.status_code == 400
 
     #Data doesnt use all 4 feature names
-    data={'failures':3, 'G1':19, 'G2':2}
+    data={'failures':2, 'G1':19, 'G2':2}
     response = client.get(url, query_string=data)
     assert response.status_code == 400
 


### PR DESCRIPTION
Following a minor bug in #17

[Description] 
Fixes the checks to enforce 'failures' values in the range 0 to 3 (inclusive), rather than 1 to 4 (inclusive) as specified by students.txt. Although students.txt says otherwise, the actual values in student-mat.csv are from 0 to 3, so those are the values our API will demand from the user.

[Testing] 
All tests in test_routes.py pass.

[Files Changed]
app/handlers/routes.py
app/tests/test_routes.py